### PR TITLE
chore: docs의 잘못된 GITHUB_PAT 변수명을 수정하고 MONITOR_GITHUB_PAT로 통일

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-GITHUB_PAT=your_github_pat
+MONITOR_GITHUB_PAT=your_github_pat
 OPENAI_API_KEY=your_openai_api_key
 GOOGLE_API_KEY=your_google_api_key
 CLAUDE_API_KEY=your_claude_api_key

--- a/.github/workflows/monitor.yaml
+++ b/.github/workflows/monitor.yaml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch: # 수동 실행 가능
 
 env:
-  GITHUB_PAT: ${{ secrets.MONITOR_GITHUB_PAT }}
+  MONITOR_GITHUB_PAT: ${{ secrets.MONITOR_GITHUB_PAT }}
   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
   GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
   CLAUDE_API_KEY: ${{ secrets.CLAUDE_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ cp .env.example .env
 Create a `.env` file with the following variables:
 
 ```
-GITHUB_PAT=your_github_pat
+MONITOR_GITHUB_PAT=your_github_pat
 OPENAI_API_KEY=your_openai_api_key
 GOOGLE_API_KEY=your_google_api_key
 CLAUDE_API_KEY=your_claude_api_key
@@ -65,7 +65,7 @@ DISCORD_WEBHOOK_URL=your_discord_webhook_url
 SLACK_WEBHOOK_URL=your_slack_webhook_url
 ```
 
-**Note:** At minimum, you need to provide `GITHUB_PAT` and either `DISCORD_WEBHOOK_URL` or `SLACK_WEBHOOK_URL`.
+**Note:** At minimum, you need to provide `MONITOR_GITHUB_PAT` and either `DISCORD_WEBHOOK_URL` or `SLACK_WEBHOOK_URL`.
 
 **Important for GitHub PAT**: When creating your GitHub Personal Access Token, make sure to enable read permissions for all repository resources, especially:
 
@@ -107,7 +107,7 @@ This repository includes a GitHub Actions workflow that automatically runs the m
 1. Fork this repository to your GitHub account
 2. Go to your forked repository's Settings > Secrets and variables > Actions
 3. Add the required environment variables as repository secrets:
-   - `GITHUB_PAT`
+   - `MONITOR_GITHUB_PAT`
    - `DISCORD_WEBHOOK_URL` or `SLACK_WEBHOOK_URL`
    - Optional: `GOOGLE_API_KEY`, `OPENAI_API_KEY`, or `CLAUDE_API_KEY` (for summarization)
 4. Edit the `.github/workflows/monitor.yml` file to customize the schedule

--- a/README_ko.md
+++ b/README_ko.md
@@ -57,7 +57,7 @@ cp .env.example .env
 다음 변수를 포함하는 `.env` 파일을 생성하세요:
 
 ```
-GITHUB_PAT=your_github_pat
+MONITOR_GITHUB_PAT=your_github_pat
 OPENAI_API_KEY=your_openai_api_key
 GOOGLE_API_KEY=your_google_api_key
 CLAUDE_API_KEY=your_claude_api_key
@@ -65,7 +65,7 @@ DISCORD_WEBHOOK_URL=your_discord_webhook_url
 SLACK_WEBHOOK_URL=your_slack_webhook_url
 ```
 
-**참고:** 최소한 `GITHUB_PAT`와 `DISCORD_WEBHOOK_URL` 또는 `SLACK_WEBHOOK_URL` 중 하나를 제공해야 합니다.
+**참고:** 최소한 `MONITOR_GITHUB_PAT`와 `DISCORD_WEBHOOK_URL` 또는 `SLACK_WEBHOOK_URL` 중 하나를 제공해야 합니다.
 
 **GitHub PAT 생성 시 중요 사항**: GitHub 개인 액세스 토큰(PAT)을 생성할 때 모든 저장소 리소스에 대한 읽기 권한을 활성화해야 합니다. 특히 다음 권한이 필요합니다:
 
@@ -107,7 +107,7 @@ export const config = {
 1. 이 저장소를 GitHub 계정으로 포크합니다
 2. 포크한 저장소의 Settings > Secrets and variables > Actions로 이동합니다
 3. 필요한 환경 변수를 저장소 시크릿으로 추가합니다:
-   - `GITHUB_PAT`
+   - `MONITOR_GITHUB_PAT`
    - `DISCORD_WEBHOOK_URL` 또는 `SLACK_WEBHOOK_URL`
    - 선택 사항: `GOOGLE_API_KEY`, `OPENAI_API_KEY`, 또는 `CLAUDE_API_KEY` (요약 기능용)
 4. `.github/workflows/monitor.yml` 파일을 편집하여 일정을 사용자 정의합니다

--- a/src/configs/config-loader.ts
+++ b/src/configs/config-loader.ts
@@ -40,7 +40,7 @@ export function loadAndValidateConfig(): AppConfig {
 function getSecretsFromEnv(): AppSecrets {
   console.log("Assembling configuration from environment variables...");
   return {
-    githubPat: process.env.GITHUB_PAT || "",
+    githubPat: process.env.MONITOR_GITHUB_PAT || "",
     openaiApiKey: process.env.OPENAI_API_KEY,
     geminiApiKey: process.env.GOOGLE_API_KEY,
     claudeApiKey: process.env.CLAUDE_API_KEY,
@@ -63,7 +63,7 @@ function getVariablesFromMonitorConfig(): AppVariables {
 function validateAppConfig(config: AppConfig): void {
   console.log("Validating configuration...");
 
-  if (config.githubPat === "") throw new Error("Missing required config: GITHUB_PAT (Secret)");
+  if (config.githubPat === "") throw new Error("Missing required config: MONITOR_GITHUB_PAT (Secret)");
 
   if (config.repoConfigs.length === 0)
     throw new Error("Missing or invalid required config: RepoConfigs");


### PR DESCRIPTION
- 문서 명에 잘못 기재되어 있는 변수명을 `GITHUB_PAT` -> `MONITOR_GITHUB_PAT` 로 변경했습니다
- 이 변경과 함께 혼동을 피하기 위해 PAT 관련 변수명을 모두 `MONITOR_GITHUB_PAT`로 통일해주었습니다.